### PR TITLE
Fix license comment spelling

### DIFF
--- a/Leetcode/shortestCompletingWord.py
+++ b/Leetcode/shortestCompletingWord.py
@@ -8,8 +8,8 @@ class Solution(object):
         """
         ## idea is to iterate through licensePlate and add the number of occurances 
         ## of each letter in dictionary. Then iterate through all the words, and 
-        ## update the answer according to the length of the smallest word that 
-        ## contains all the letter from licence plate.
+        ## update the answer according to the length of the smallest word that
+        ## contains all the letter from license plate.
         ans = ""
         d = collections.defaultdict(int)
         for c in licensePlate:


### PR DESCRIPTION
## Summary
- fix spelling of 'license plate' in a comment

## Testing
- `grep -n licence -n Leetcode/shortestCompletingWord.py`

------
https://chatgpt.com/codex/tasks/task_e_6872f36019f883309d0924d01644441c